### PR TITLE
feat: Add SQS support

### DIFF
--- a/app_common_python/types.py
+++ b/app_common_python/types.py
@@ -30,6 +30,9 @@ class AppConfig:
 
         #: ClowdApp deployment configuration for Clowder enabled apps.
         self.kafka = None
+        
+        #: ClowdApp deploymnet configuration for Cloweder enabled apps.
+        self.sqs = None
 
         #: ClowdApp deployment configuration for Clowder enabled apps.
         self.database = None
@@ -68,6 +71,8 @@ class AppConfig:
         obj.logging = LoggingConfig.dictToObject(dict.get('logging', None))
 
         obj.kafka = KafkaConfig.dictToObject(dict.get('kafka', None))
+        
+        obj.sqs = SQSConfig.dictToObject(dict.get('sqs', None))
 
         obj.database = DatabaseConfig.dictToObject(dict.get('database', None))
 
@@ -140,6 +145,40 @@ class KafkaConfig:
         for elemTopics in arrayTopics:
             obj.topics.append(
                 TopicConfig.dictToObject(elemTopics))
+        return obj
+    
+
+class SQSConfig:
+    """SQS Configuration
+    """
+    
+    def __init__(self):
+        
+        #: SQS Configuration
+        self.name = None
+        
+        #: SQS Configuration
+        self.accesskey = None
+        
+        #: SQS Configuration
+        self.secretkey = None
+
+        #: SQS Configuration
+        self.region = None
+        
+    @classmethod
+    def dictToObject(cls, dict):
+        if dict is None:
+            return None
+        obj = cls()
+        
+        obj.name = dict.get('name', None)
+        
+        obj.accesskey = dict.get('accesskey', None)
+        
+        obj.secretkey = dict.get('secretkey', None)
+        
+        obj.region = dict.get('region', None)
         return obj
 
 

--- a/schema.json
+++ b/schema.json
@@ -139,6 +139,32 @@
                 "topics"
             ]
         },
+        "SQSConfig": {
+            "id": "sqsConfig",
+            "type": "object",
+            "description": "SQS Configuration",
+            "properties": {
+                "name": {
+                    "description": "Defines the url of the SQS queue",
+                    "type": "string"
+                },
+                "accesskey": {
+                    "description": "Access Key for the SQS queue",
+                    "type": "string"
+                },
+                "secretkey": {
+                    "description": "Secret Key for the SQS queue",
+                    "type": "string"
+                },
+                "region": {
+                    "description": "Region of the SQS queue",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "name"
+            ]
+        },
         "BrokerConfig": {
             "id": "brokerConfig",
             "type": "object",

--- a/test.json
+++ b/test.json
@@ -26,6 +26,12 @@
             }
         ]
     },
+    "sqs": {
+        "name": "https://some-amazon-url.com/some-queue",
+        "accesskey": "someaccesskey",
+        "secretkey": "somesecretkey",
+        "region": "us-east-1"
+    },
     "database": {
         "name": "dBaseName",
         "username": "username",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,3 +14,4 @@ def test_load_config():
         assert ca_content == "ca"
     assert isClowderEnabled() == True
     assert LoadedConfig.featureFlags.hostname == "ff-server.server.example.com"
+    assert LoadedConfig.sqs.name == "https://some-amazon-url.com/some-queue"


### PR DESCRIPTION
We have at least one app, and probably more that will require Amazon SQS
support. It would be cool if we could configure this via clowder. Added
the support for it following what looked to be the standard way other
types were implemented.

Signed-off-by: Stephen Adams <tsadams@gmail.com>