### PR TITLE
[feat] enable logging of BrokerConfig

### DIFF
--- a/app_common_python/types.py
+++ b/app_common_python/types.py
@@ -447,7 +447,9 @@ class BrokerConfig:
 
         obj.sasl = KafkaSASLConfig.dictToObject(dict.get('sasl', None))
         return obj
-
+    
+    def __str__(self):
+        return "hostname: {0}, port: {1}, authtype: {3}, sasl: {4}".format(self.hostname, self.port, self.authtype, self.sasl)
 
 class TopicConfig:
     """ Topic Configuration


### PR DESCRIPTION
I have a couple apps that attempt to log the brokerconfig and end up
just logging the object. Would be good to be able to log it and see the
actual data in the object

Signed-off-by: Stephen Adams <tsadams@gmail.com>