### PR TITLE
Add tlsPort to FeatureFlagConfig

### DIFF
--- a/app_common_python/types.py
+++ b/app_common_python/types.py
@@ -344,6 +344,9 @@ class FeatureFlagsConfig:
         self.port = None
 
         #: Feature Flags Configuration
+        self.tlsPort = None
+
+        #: Feature Flags Configuration
         self.clientAccessToken = None
 
         #: Feature Flags Configuration
@@ -358,6 +361,8 @@ class FeatureFlagsConfig:
         obj.hostname = dict.get('hostname', None)
 
         obj.port = dict.get('port', None)
+
+        obj.port = dict.get('tlsPort', None)
 
         obj.clientAccessToken = dict.get('clientAccessToken', None)
 


### PR DESCRIPTION
This PR adds tlsPort to types.FeatureFlagConfig, which is used by `unleash`.  This work is being done as a part of[ RHINENG-98](https://issues.redhat.com/browse/RHINENG-98) 