### PR TITLE
Regenerate for latest schema

### DIFF
--- a/app_common_python/types.py
+++ b/app_common_python/types.py
@@ -18,6 +18,12 @@ class AppConfig:
         self.publicPort = None
 
         #: ClowdApp deployment configuration for Clowder enabled apps.
+        self.h2cPrivatePort = None
+
+        #: ClowdApp deployment configuration for Clowder enabled apps.
+        self.h2cPublicPort = None
+
+        #: ClowdApp deployment configuration for Clowder enabled apps.
         self.webPort = None
 
         #: ClowdApp deployment configuration for Clowder enabled apps.
@@ -60,7 +66,13 @@ class AppConfig:
         self.BOPURL = None
 
         #: ClowdApp deployment configuration for Clowder enabled apps.
+        self.hashCache = None
+
+        #: ClowdApp deployment configuration for Clowder enabled apps.
         self.hostname = None
+
+        #: ClowdApp deployment configuration for Clowder enabled apps.
+        self.prometheusGateway = None
 
     @classmethod
     def dictToObject(cls, dict):
@@ -71,6 +83,10 @@ class AppConfig:
         obj.privatePort = dict.get('privatePort', None)
 
         obj.publicPort = dict.get('publicPort', None)
+
+        obj.h2cPrivatePort = dict.get('h2cPrivatePort', None)
+
+        obj.h2cPublicPort = dict.get('h2cPublicPort', None)
 
         obj.webPort = dict.get('webPort', None)
 
@@ -106,7 +122,11 @@ class AppConfig:
 
         obj.BOPURL = dict.get('BOPURL', None)
 
+        obj.hashCache = dict.get('hashCache', None)
+
         obj.hostname = dict.get('hostname', None)
+
+        obj.prometheusGateway = PrometheusGatewayConfig.dictToObject(dict.get('prometheusGateway', None))
         return obj
 
 
@@ -397,6 +417,15 @@ class DependencyEndpoint:
         self.tlsPort = None
 
         #: Dependent service connection info
+        self.h2cPort = None
+
+        #: Dependent service connection info
+        self.h2cTLSPort = None
+
+        #: Dependent service connection info
+        self.tlsCAPath = None
+
+        #: Dependent service connection info
         self.apiPath = None
 
         #: Dependent service connection info
@@ -417,6 +446,12 @@ class DependencyEndpoint:
         obj.app = dict.get('app', None)
 
         obj.tlsPort = dict.get('tlsPort', None)
+
+        obj.h2cPort = dict.get('h2cPort', None)
+
+        obj.h2cTLSPort = dict.get('h2cTLSPort', None)
+
+        obj.tlsCAPath = dict.get('tlsCAPath', None)
 
         obj.apiPath = dict.get('apiPath', None)
 
@@ -447,6 +482,15 @@ class PrivateDependencyEndpoint:
         #: Dependent service connection info
         self.tlsPort = None
 
+        #: Dependent service connection info
+        self.h2cPort = None
+
+        #: Dependent service connection info
+        self.h2cTLSPort = None
+
+        #: Dependent service connection info
+        self.tlsCAPath = None
+
     @classmethod
     def dictToObject(cls, dict):
         if dict is None:
@@ -462,6 +506,36 @@ class PrivateDependencyEndpoint:
         obj.app = dict.get('app', None)
 
         obj.tlsPort = dict.get('tlsPort', None)
+
+        obj.h2cPort = dict.get('h2cPort', None)
+
+        obj.h2cTLSPort = dict.get('h2cTLSPort', None)
+
+        obj.tlsCAPath = dict.get('tlsCAPath', None)
+        return obj
+
+
+class PrometheusGatewayConfig:
+    """ Prometheus Gateway Configuration
+    """
+
+    def __init__(self):
+
+        #: Prometheus Gateway Configuration
+        self.hostname = None
+
+        #: Prometheus Gateway Configuration
+        self.port = None
+
+    @classmethod
+    def dictToObject(cls, dict):
+        if dict is None:
+            return None
+        obj = cls()
+
+        obj.hostname = dict.get('hostname', None)
+
+        obj.port = dict.get('port', None)
         return obj
 
 

--- a/schema.json
+++ b/schema.json
@@ -16,12 +16,20 @@
                     "description": "Defines the public port that the app should be configured to listen on for API traffic.",
                     "type": "integer"
                 },
+                "h2cPrivatePort": {
+                    "description": "Defines the private H2C port that the app should be configured to listen on for H2C traffic.",
+                    "type": "integer"
+                },
+                "h2cPublicPort": {
+                    "description": "Defines the public H2C port that the app should be configured to listen on for H2C traffic.",
+                    "type": "integer"
+                },
                 "webPort": {
                     "description": "Deprecated: Use 'publicPort' instead.",
                     "type": "integer"
                 },
                 "tlsCAPath": {
-                    "description": "Defines the port CA path",
+                    "description": "Defines path to default CA certificate for TLS connections to other ClowdApps. Only populated when TLS is enabled for entire ClowdEnvironment.",
                     "type": "string"
                 },
                 "metricsPort": {
@@ -71,9 +79,16 @@
                     "description": "Defines the path to the BOPURL.",
                     "type": "string"
                 },
+                "hashCache": {
+                    "description": "A set of configMap/secret hashes",
+                    "type": "string"
+                },
                 "hostname": {
                     "description": "The external hostname of the deployment, where applicable",
                     "type": "string"
+                },
+                "prometheusGateway": {
+                    "$ref": "#/definitions/PrometheusGatewayConfig"
                 }
             },
             "required": [
@@ -488,6 +503,18 @@
                     "description": "The TLS port of the dependent service.",
                     "type": "integer"
                 },
+                "h2cPort": {
+                    "description": "The H2C port of the dependent service.",
+                    "type": "integer"
+                },
+                "h2cTLSPort": {
+                    "description": "The H2C TLS port of the dependent service.",
+                    "type": "integer"
+                },
+                "tlsCAPath": {
+                    "description": "Defines path to CA certificate for TLS connections to this ClowdApp. If present, this should override use of default TLS CA path.",
+                    "type": "string"
+                },
                 "apiPath": {
                     "description": "The top level api path that the app should serve from /api/<apiPath> (deprecated, use apiPaths)",
                     "type": "string"
@@ -532,6 +559,18 @@
                 "tlsPort": {
                     "description": "The TLS port of the dependent service.",
                     "type": "integer"
+                },
+                "h2cPort": {
+                    "description": "The H2C port of the dependent service.",
+                    "type": "integer"
+                },
+                "h2cTLSPort": {
+                    "description": "The H2C TLS port of the dependent service.",
+                    "type": "integer"
+                },
+                "tlsCAPath": {
+                    "description": "Defines path to CA certificate for TLS connections to this ClowdApp. If present, this should override use of default TLS CA path.",
+                    "type": "string"
                 }
             },
             "required": [
@@ -539,6 +578,25 @@
                 "hostname",
                 "port",
                 "app"
+            ]
+        },
+        "PrometheusGatewayConfig": {
+            "id": "prometheusGatewayConfig",
+            "type": "object",
+            "description": "Prometheus Gateway Configuration",
+            "properties": {
+                "hostname": {
+                    "description": "Defines the hostname for the Prometheus Gateway server configuration.",
+                    "type": "string"
+                },
+                "port": {
+                    "description": "Defines the port for the Prometheus Gateway server configuration.",
+                    "type": "integer"
+                }
+            },
+            "required": [
+                "hostname",
+                "port"
             ]
         }
     }


### PR DESCRIPTION
Incorporates new features added to schema:
  - H2C port support: Added h2cPrivatePort and h2cPublicPort to AppConfig for HTTP/2 Cleartext traffic handling
  - Prometheus Gateway configuration: New PrometheusGatewayConfig class with hostname and port configuration in AppConfig
  - Enhanced TLS paths: Added tlsCAPath to both DependencyEndpoint and PrivateDependencyEndpoint for custom CA certificate paths per ClowdApp
  - Hash cache: Added hashCache field to AppConfig for configMap/secret hash tracking
  - H2C endpoint support: Added h2cPort and h2cTLSPort to dependency endpoint types