### PR TITLE
feat: Add V2 dependency endpoints support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,56 @@ def main():
         print(f"Hostname: {LoadedConfig.hostname}")
 ```
 
+The ``clowder`` library also comes with several other helpers
+
+* ``LoadedConfig.rds_ca()`` - creates a temporary file with the RDSCa and
+  returns the filename.
+* ``LoadedConfig.kafka_ca()`` - creates a temporary file with the KafkaCa and
+  returns the filename from the frist broker in the list.
+* ``KafkaTopics`` - returns a map of KafkaTopics using the requestedName
+  as the key and the topic object as the value.
+* ``KafkaServers`` - returns a list of Kafka Broker URLs.
+* ``ObjectBuckets`` - returns a list of ObjectBuckets using the requestedName
+  as the key and the bucket object as the value.
+* ``DependencyEndpoints`` - returns a nested map using \[appName\]\[deploymentName\]
+  for the public services of requested applications.
+* ``PrivateDependencyEndpoints`` - returns a nested map using \[appName\]\[deploymentName\]
+  for the private services of requested applications.
+* ``DependencyEndpointsV2`` - returns a nested map using \[appName\]\[endpointName\]
+  for V2 dependency endpoints with simplified connection info.
+* ``get_v2_dependency_endpoint(app, endpoint)`` - returns a single V2 endpoint
+  or ``None`` if not found.
+
+V2 Dependency Endpoints
+-----------------------
+
+V2 endpoints provide simplified, opinionated configuration for service-to-service
+connections. Each endpoint includes a single URI, an authentication flag, and an
+optional CA certificate path.
+
+```python
+from app_common_python import DependencyEndpointsV2, get_v2_dependency_endpoint, isClowderEnabled
+
+if isClowderEnabled():
+    # Access via the nested map
+    rbac = DependencyEndpointsV2["rbac"]["service"]
+    print(f"URI: {rbac.uri}")
+    print(f"Authenticated: {rbac.authenticated}")
+    if rbac.ca_certificate:
+        print(f"CA Cert: {rbac.ca_certificate}")
+
+    # Or use the helper function
+    ep = get_v2_dependency_endpoint("rbac", "service")
+    if ep:
+        print(f"URI: {ep.uri}")
+```
+
+V2 endpoint fields:
+* ``uri`` - Full URI for the service (e.g. ``https://rbac-service.env.svc:8443``)
+* ``authenticated`` - ``True`` for cross-cluster (ClowdAppRef), ``False`` for in-cluster
+* ``ca_certificate`` - Path to CA certificate for TLS (only present for in-cluster TLS)
+
+
 ### API Overview
 
 The library provides several convenience accessors for common configuration lookups:

--- a/app_common_python/__init__.py
+++ b/app_common_python/__init__.py
@@ -1,7 +1,7 @@
 import json
 import os
 import tempfile
-from .types import AppConfig
+from .types import AppConfig, V2Endpoint
 
 
 class SmartAppConfig(AppConfig):
@@ -60,6 +60,20 @@ if LoadedConfig.privateEndpoints and len(LoadedConfig.privateEndpoints) > 0:
         if endpoint.app not in PrivateDependencyEndpoints:
             PrivateDependencyEndpoints[endpoint.app] = {}
         PrivateDependencyEndpoints[endpoint.app][endpoint.name] = endpoint
+
+DependencyEndpointsV2 = {}
+if LoadedConfig.dependencyEndpoints:
+    DependencyEndpointsV2 = LoadedConfig.dependencyEndpoints
+
+
+def get_v2_dependency_endpoint(app, endpoint):
+    if not DependencyEndpointsV2:
+        return None
+    app_endpoints = DependencyEndpointsV2.get(app)
+    if not app_endpoints:
+        return None
+    return app_endpoints.get(endpoint)
+
 
 KafkaServers = []
 if LoadedConfig.kafka and len(LoadedConfig.kafka.brokers) > 0:

--- a/app_common_python/types.py
+++ b/app_common_python/types.py
@@ -57,6 +57,9 @@ class AppConfig:
         self.featureFlags = None
 
         #: ClowdApp deployment configuration for Clowder enabled apps.
+        self.dependencyEndpoints = None
+
+        #: ClowdApp deployment configuration for Clowder enabled apps.
         self.endpoints = []
 
         #: ClowdApp deployment configuration for Clowder enabled apps.
@@ -109,6 +112,17 @@ class AppConfig:
         obj.inMemoryDb = InMemoryDBConfig.dictToObject(dict.get('inMemoryDb', None))
 
         obj.featureFlags = FeatureFlagsConfig.dictToObject(dict.get('featureFlags', None))
+
+        depEndpoints = dict.get('dependencyEndpoints', None)
+        if depEndpoints is not None:
+            v2Dict = depEndpoints.get('v2', None)
+            if v2Dict is not None:
+                obj.dependencyEndpoints = {}
+                for appName, endpoints in v2Dict.items():
+                    obj.dependencyEndpoints[appName] = {}
+                    for endpointName, endpointData in endpoints.items():
+                        obj.dependencyEndpoints[appName][endpointName] = \
+                            V2Endpoint.dictToObject(endpointData)
 
         arrayEndpoints = dict.get('endpoints', [])
         for elemEndpoints in arrayEndpoints:
@@ -392,6 +406,32 @@ class FeatureFlagsConfig:
         obj.clientAccessToken = dict.get('clientAccessToken', None)
 
         obj.scheme = FeatureFlagsConfigSchemeEnum.valueForString(dict.get('scheme', None))
+        return obj
+
+
+class V2Endpoint:
+    """ V2 dependency endpoint with simplified connection info.
+    """
+
+    def __init__(self):
+
+        self.uri = None
+
+        self.ca_certificate = None
+
+        self.authenticated = None
+
+    @classmethod
+    def dictToObject(cls, dict):
+        if dict is None:
+            return None
+        obj = cls()
+
+        obj.uri = dict.get('uri', None)
+
+        obj.ca_certificate = dict.get('ca_certificate', None)
+
+        obj.authenticated = dict.get('authenticated', None)
         return obj
 
 

--- a/schema.json
+++ b/schema.json
@@ -89,6 +89,9 @@
                 },
                 "prometheusGateway": {
                     "$ref": "#/definitions/PrometheusGatewayConfig"
+                },
+                "dependencyEndpoints": {
+                    "$ref": "#/definitions/DependencyEndpointsConfig"
                 }
             },
             "required": [
@@ -579,6 +582,46 @@
                 "port",
                 "app"
             ]
+        },
+        "V2Endpoint": {
+            "id": "v2Endpoint",
+            "type": "object",
+            "description": "V2 dependency endpoint with simplified connection info",
+            "properties": {
+                "uri": {
+                    "description": "The URI of the dependent service.",
+                    "type": "string"
+                },
+                "ca_certificate": {
+                    "description": "Path to the CA certificate for TLS connections to this service.",
+                    "type": "string"
+                },
+                "authenticated": {
+                    "description": "Whether the endpoint requires authentication.",
+                    "type": "boolean"
+                }
+            },
+            "required": [
+                "uri",
+                "authenticated"
+            ]
+        },
+        "DependencyEndpointsConfig": {
+            "id": "dependencyEndpointsConfig",
+            "type": "object",
+            "description": "V2 dependency endpoints configuration, keyed by app name and endpoint name",
+            "properties": {
+                "v2": {
+                    "description": "V2 format dependency endpoints, organized as app -> endpoint -> config",
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object",
+                        "additionalProperties": {
+                            "$ref": "#/definitions/V2Endpoint"
+                        }
+                    }
+                }
+            }
         },
         "PrometheusGatewayConfig": {
             "id": "prometheusGatewayConfig",

--- a/test.json
+++ b/test.json
@@ -90,5 +90,22 @@
             "hostname": "endpoint2.svc",
             "port": 10000
         }
-    ]
+    ],
+    "dependencyEndpoints": {
+        "v2": {
+            "app1": {
+                "service": {
+                    "uri": "https://app1-service.env.svc:8443",
+                    "ca_certificate": "/cdapp/certs/service-ca.crt",
+                    "authenticated": false
+                }
+            },
+            "app2": {
+                "api": {
+                    "uri": "https://app2-api.env.svc:8443",
+                    "authenticated": true
+                }
+            }
+        }
+    }
 }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,4 +1,10 @@
-from app_common_python import LoadedConfig, KafkaTopics, DependencyEndpoints, ObjectBuckets, KafkaServers, isClowderEnabled, PrivateDependencyEndpoints
+from app_common_python import (
+    LoadedConfig, KafkaTopics, DependencyEndpoints, ObjectBuckets,
+    KafkaServers, isClowderEnabled, PrivateDependencyEndpoints,
+    DependencyEndpointsV2, get_v2_dependency_endpoint, loadConfig,
+)
+from app_common_python.types import V2Endpoint
+
 
 def test_load_config():
     assert LoadedConfig.kafka.brokers[0].port == 27015, "Port failed to be found"
@@ -21,3 +27,49 @@ def test_load_config():
     assert isClowderEnabled() == True
     assert LoadedConfig.featureFlags.hostname == "ff-server.server.example.com"
     assert LoadedConfig.hostname == "testing"
+
+
+def test_v2_dependency_endpoints_parsed():
+    assert "app1" in DependencyEndpointsV2
+    assert "app2" in DependencyEndpointsV2
+    assert "service" in DependencyEndpointsV2["app1"]
+    assert "api" in DependencyEndpointsV2["app2"]
+
+
+def test_v2_endpoint_fields():
+    ep = DependencyEndpointsV2["app1"]["service"]
+    assert isinstance(ep, V2Endpoint)
+    assert ep.uri == "https://app1-service.env.svc:8443"
+    assert ep.ca_certificate == "/cdapp/certs/service-ca.crt"
+    assert ep.authenticated is False
+
+
+def test_v2_endpoint_authenticated_cross_cluster():
+    ep = DependencyEndpointsV2["app2"]["api"]
+    assert ep.uri == "https://app2-api.env.svc:8443"
+    assert ep.ca_certificate is None
+    assert ep.authenticated is True
+
+
+def test_get_v2_dependency_endpoint():
+    ep = get_v2_dependency_endpoint("app1", "service")
+    assert ep is not None
+    assert ep.uri == "https://app1-service.env.svc:8443"
+
+
+def test_get_v2_dependency_endpoint_missing_app():
+    assert get_v2_dependency_endpoint("nonexistent", "service") is None
+
+
+def test_get_v2_dependency_endpoint_missing_endpoint():
+    assert get_v2_dependency_endpoint("app1", "nonexistent") is None
+
+
+def test_v2_missing_from_config():
+    config = loadConfig(None)
+    assert config.dependencyEndpoints is None
+
+
+def test_v1_endpoints_unchanged():
+    assert DependencyEndpoints["app1"]["endpoint1"].port == 8000
+    assert PrivateDependencyEndpoints["app1"]["endpoint1"].port == 10000


### PR DESCRIPTION
## Summary
- Adds parsing and public API for Clowder's new V2 dependency endpoints (`dependencyEndpoints.v2` in `cdappconfig.json`)
- V2 endpoints provide simplified connection info: single `uri`, `authenticated` flag, and optional `ca_certificate` path
- Exposes `DependencyEndpointsV2` dict and `get_v2_dependency_endpoint(app, endpoint)` helper function
- Fully backward compatible — existing V1 API is unchanged

## Changes
- **`types.py`** — `V2Endpoint` class + `dependencyEndpoints` field on `AppConfig` with nested dict parsing
- **`__init__.py`** — `DependencyEndpointsV2` module-level dict + `get_v2_dependency_endpoint()` helper
- **`test.json`** — V2 fixture data (in-cluster with CA cert + cross-cluster authenticated)
- **`tests/test_config.py`** — 8 new tests: parsing, field values, helper function, missing data, backward compat
- **`README.md`** — V2 usage docs with code examples

## Dependencies
- Requires ENGPROD-9703 (Clowder generating V2 endpoints) to be deployed for runtime usage

## Test plan
- [x] All 9 tests pass (`ACG_CONFIG="test.json" pytest -v`)
- [x] Original V1 test unchanged and passing
- [x] V2 parsing covers in-cluster (with CA cert) and cross-cluster (authenticated) cases
- [x] Edge cases: missing V2 data, missing app, missing endpoint all return `None`

🤖 Generated with [Claude Code](https://claude.com/claude-code)